### PR TITLE
Refactor run command and update README.md for breakpoint requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,17 +156,16 @@ Load a binary file for debugging:
 ```
 
 #### 3. Run
-Run the loaded binary (set breakpoints first or use interrupt_after):
+Run the loaded binary (requires at least one enabled breakpoint set beforehand):
 ```json
 {
   "tool": "run",
   "arguments": {
-    "args": "arg1 arg2",
-    "interrupt_after": 5.0
+    "args": "arg1 arg2"
   }
 }
 ```
-Note: Either set breakpoints before running (recommended) or use `interrupt_after` to pause execution.
+Note: You must set at least one enabled breakpoint before running.
 
 #### 4. Step Control
 Control program execution:
@@ -288,18 +287,13 @@ List all tracked background processes:
    {"tool": "set_file", "arguments": {"binary_path": "/path/to/binary"}}
    ```
 
-2. Choose your debugging approach:
+2. Prepare breakpoints, then run:
    
-   **Option A: Set breakpoints (recommended)**
    ```json
    {"tool": "set_breakpoint", "arguments": {"location": "main"}}
    {"tool": "run", "arguments": {"args": ""}}
    ```
    
-   **Option B: Run with timed interrupt**
-   ```json
-   {"tool": "run", "arguments": {"args": "", "interrupt_after": 3.0}}
-   ```
 
 3. Use stepping commands and examine state:
    ```json

--- a/pwnomcp/gdb/controller.py
+++ b/pwnomcp/gdb/controller.py
@@ -532,61 +532,7 @@ class GdbController:
             "state": self._state
         }
         
-    def interrupt(self) -> Dict[str, Any]:
-        """Send interrupt signal to the running program"""
-        logger.info("Sending interrupt signal to GDB")
-        
-        # Use pygdbmi's interrupt_gdb method
-        try:
-            self.controller.interrupt_gdb()
-            # Give it a moment to process
-            import time
-            time.sleep(0.1)
-            
-            # Check for any output
-            responses = self.controller.get_gdb_response(timeout_sec=1.0, raise_error_on_timeout=False)
-            output_lines = []
-            
-            for response in responses:
-                if response.get("type") == "console" and response.get("payload"):
-                    output_lines.append(response["payload"])
-                elif response.get("type") == "notify":
-                    self._handle_notify(response)
-                    
-            return {
-                "success": True,
-                "output": "".join(output_lines),
-                "state": self._state
-            }
-        except Exception as e:
-            logger.error(f"Failed to interrupt: {e}")
-            return {
-                "success": False,
-                "error": str(e),
-                "state": self._state
-            }
-
-    def interrupt_execution(self, all_threads: bool = False, thread_group: Optional[str] = None) -> Dict[str, Any]:
-        """Interrupt target using MI command (-exec-interrupt)
-
-        :param all_threads: If True, interrupt all threads (non-stop mode)
-        :param thread_group: Optional thread group identifier to interrupt
-        :returns: Structured interrupt result
-        """
-        mi_cmd = "-exec-interrupt"
-        if all_threads:
-            mi_cmd += " --all"
-        elif thread_group:
-            mi_cmd += f" --thread-group {thread_group}"
-
-        result = self.execute_mi_command(mi_cmd)
-
-        return {
-            "command": mi_cmd,
-            "output": "\n".join(result["output"]) if result["output"] else "",
-            "error": result["error"],
-            "state": self._state
-        }
+    
         
     def get_state(self) -> str:
         """Get current inferior state"""

--- a/pwnomcp/mcp.py
+++ b/pwnomcp/mcp.py
@@ -139,20 +139,17 @@ async def attach(pid: int) -> str:
 
 
 @mcp.tool()
-async def run(args: str = "", interrupt_after: Optional[float] = None, start: bool = False) -> str:
+async def run(args: str = "", start: bool = False) -> str:
     """
     Run the loaded binary.
     
-    Before running, you should either:
-    1. Set breakpoints at key locations (recommended), OR
-    2. Use interrupt_after to pause execution after N seconds
+    Requires at least one enabled breakpoint to be set before running.
 
     :param args: Arguments to pass to the binary
-    :param interrupt_after: Optional - interrupt execution after N seconds
     :param start: Optional - stop at program entry (equivalent to --start)
     :returns: Execution results and state
     """
-    result = pwndbg_tools.run(args, interrupt_after, start)
+    result = pwndbg_tools.run(args, start)
     return format_launch_result(result)
 
 
@@ -176,19 +173,6 @@ async def finish() -> str:
     :returns: Execution results and new state
     """
     result = pwndbg_tools.finish()
-    return format_step_result(result)
-
-
-@mcp.tool()
-async def interrupt(all_threads: bool = False, thread_group: Optional[str] = None) -> str:
-    """
-    Interrupt the target's execution.
-
-    :param all_threads: Interrupt all threads (non-stop mode)
-    :param thread_group: Interrupt only the specified thread group
-    :returns: Interrupt results and state
-    """
-    result = pwndbg_tools.interrupt_execution(all_threads=all_threads, thread_group=thread_group)
     return format_step_result(result)
 
 


### PR DESCRIPTION
- Modified the `run` function in `mcp.py` and `pwndbg.py` to enforce the requirement of at least one enabled breakpoint before execution, removing the `interrupt_after` parameter.
- Updated the README.md to reflect the new requirement for breakpoints when running the loaded binary, enhancing user guidance on debugging procedures.
- Removed the `interrupt` method from `GdbController` and related interrupt functionality, streamlining the codebase.